### PR TITLE
Feature request time delayed

### DIFF
--- a/lib/Plack/Middleware/AccessLog/Structured.pm
+++ b/lib/Plack/Middleware/AccessLog/Structured.pm
@@ -127,11 +127,11 @@ sub call {
 
 	my $t_before = Time::HiRes::time();
 	my $res = $self->app->($env);
-	my $t_after = Time::HiRes::time();
 
 	return $self->response_cb($res, sub {
 		my ($cb_res) = @_;
 
+		my $t_after = Time::HiRes::time();
 		my $h = Plack::Util::headers($cb_res->[1]);
 		my $content_type = $h->get('Content-Type');
 		my $log_entry = {


### PR DESCRIPTION
Hello! I came across this package today, and noticed that request_duration is being calculated early. This should make it reflect the entire duration of the response.

Let me know if there's anything that should be changed.

Cheers!